### PR TITLE
Docstrings can be a single line

### DIFF
--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -25,11 +25,6 @@ black_format_file_in_place = black.format_file_in_place
 def is_docstring(leaf: Leaf) -> bool:
     # Most of this function was copied from Black!
 
-    if not is_multiline_string(leaf):
-        # For the purposes of docstring re-indentation, we don't need to do anything
-        # with single-line docstrings.
-        return False
-
     if prev_siblings_are(
         leaf.parent, [None, token.NEWLINE, token.INDENT, syms.simple_stmt]
     ):

--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -36,7 +36,7 @@ def is_docstring(leaf: Leaf) -> bool:
         # grammar. We're safe to return True without further checks.
         return True
 
-    if leaf.parent.prev_sibling is None:
+    if leaf.parent.prev_sibling is None and leaf.column == 0:
         # Identify module docstrings.
         return True
 


### PR DESCRIPTION
Closes #3

It seems like black uses `is_docstring()` both for re-indentation and
re-quoting strings, but for our use case, we only care about re-quoting.  And
docstrings can be a single line, so they should get re-quoted.