### PR TITLE
Move black to install_requires and remove blue import from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -e .
-black
 doc8
 flake8
 pylint

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
+import pathlib
+import re
+
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
-
-import blue
 
 
 class Tox(TestCommand):
@@ -18,9 +19,13 @@ class Tox(TestCommand):
 with open('README.rst') as reader:
     readme = reader.read()
 
+blue_init = (pathlib.Path('blue') / '__init__.py').read_text()
+match = re.search(r"^__version__ = '(.+)'$", blue_init, re.MULTILINE)
+version = match.group(1)
+
 setup(
-    name=blue.__title__,
-    version=blue.__version__,
+    name='blue',
+    version=version,
     description='Blue -- Some folks like black but I prefer blue.',
     long_description=readme,
     author='Grant Jenks',
@@ -35,7 +40,7 @@ setup(
         'Documentation': 'https://blue.readthedocs.io/en/latest',
         'Source': 'https://github.com/grantjenks/blue.git',
         'Tracker': 'https://github.com/grantjenks/blue/issues',
-        },
+    },
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
@@ -43,10 +48,10 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist=py35,py36,py37,py38,lint
+envlist=py36,py37,py38,py39,lint
 skip_missing_interpreters=True
 
 [testenv]
 deps=
-    black
     pytest
     pytest-xdist
 commands=pytest
@@ -16,7 +15,6 @@ testpaths=blue docs tests
 
 [testenv:lint]
 deps=
-    black
     doc8
     flake8
     rstcheck


### PR DESCRIPTION
- Read the version from the blue/__init__.py via regex
- Remove "black" from development requirements.txt
- Drop support for Python 3.5 (matching black)
- Drop black install from tox (now handled by setup.py)