### PR TITLE
Preserve whitespace before hash mark on hanging comments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,9 @@ Here is a brief list of differences between ``blue`` and ``black``:
   creates a pyproject.toml just to change this one setting so making it
   consistent with PEP 8 seems relatively harmless.
 
+* ``blue`` preserves the whitespace before the hash mark for right hanging
+  comments.
+
 We are `accumulating <https://github.com/grantjenks/blue/issues/2>`_ a list of
 other deviations we are considering.  As we decide to implement any particular
 suggestion, we'll turn those into individual issues and tackle them

--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -174,7 +174,6 @@ def parse_pyproject_toml(path_config: str) -> Dict[str, Any]:
 # https://github.com/grantjenks/blue/issues/14
 @lru_cache(maxsize=4096)
 def list_comments(prefix: str, *, is_endmarker: bool) -> List[ProtoComment]:
-    """Return a list of :class:`ProtoComment` objects parsed from the given `prefix`."""
     result: List[ProtoComment] = []
     if not prefix or "#" not in prefix:
         return result
@@ -182,9 +181,9 @@ def list_comments(prefix: str, *, is_endmarker: bool) -> List[ProtoComment]:
     consumed = 0
     nlines = 0
     ignored_lines = 0
-    for index, original_line in enumerate(prefix.split("\n")):
-        consumed += len(original_line) + 1  # adding the length of the split '\n'
-        line = original_line.lstrip()
+    for index, orig_line in enumerate(prefix.split("\n")):
+        consumed += len(orig_line) + 1  # adding the length of the split '\n'
+        line = orig_line.lstrip()
         breakpoint()
         if not line:
             nlines += 1
@@ -200,10 +199,12 @@ def list_comments(prefix: str, *, is_endmarker: bool) -> List[ProtoComment]:
             comment_type = token.COMMENT  # simple trailing comment
         else:
             comment_type = STANDALONE_COMMENT
-        comment = original_line[:-len(line)] + make_comment(line)
+        # Restore the original whitespace.
+        comment = orig_line[:-len(line)] + make_comment(line)
         result.append(
             ProtoComment(
-                type=comment_type, value=comment, newlines=nlines, consumed=consumed
+                type=comment_type, value=comment, newlines=nlines,
+                consumed=consumed
             )
         )
         nlines = 0

--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -65,7 +65,7 @@ BLUE_MONKEYPATCHES = [
     # Asynchronous Monkees.
     ('normalize_string_quotes', Mode.asynchronous),
     ('list_comments', Mode.asynchronous),
-    ]
+]
 
 
 def monkey_patch_black(mode: Mode) -> None:

--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -147,9 +147,11 @@ def normalize_string_quotes(leaf: Leaf) -> None:
 
 
 def format_file_in_place(*args, **kws):
-    # Black does some clever aync/parallelization so apply monkey patches here
-    # too.
+    # Black does some clever aync/parallelization so apply some monkey patches
+    # here too.  We figure this out by looking at what works when formatting a
+    # single file vs multiple files.
     black.normalize_string_quotes = normalize_string_quotes
+    black.list_comments = list_comments
     return black_format_file_in_place(*args, **kws)
 
 
@@ -233,7 +235,6 @@ def monkey_patch_black():
     black.format_file_in_place = format_file_in_place
     black.normalize_string_quotes = normalize_string_quotes
     black.parse_pyproject_toml = parse_pyproject_toml
-    black.list_comments = list_comments
     # Change the default line length to 79 characters.
     line_length_param = black.main.params[1]
     assert line_length_param.name == 'line_length'

--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -52,6 +52,7 @@ black.CACHE_DIR = Path(user_cache_dir('blue', version=__version__))
 # after the subprocesses have been spawned.  Define your monkey patch points
 # here.
 
+
 class Mode(Enum):
     asynchronous = 1
     synchronous = 2
@@ -75,6 +76,12 @@ def monkey_patch_black(mode: Mode) -> None:
             setattr(black, function_name, getattr(blue, function_name))
 
 
+# Because blue makes different choices than black, and all of this code is
+# essentially ripped off from black, applying blue to it will change the
+# formatting.  That will make diff'ing with black more difficult, so just turn
+# off formatting for anything that comes from black.
+
+# fmt: off
 def is_docstring(leaf: Leaf) -> bool:
     # Most of this function was copied from Black!
 
@@ -261,6 +268,7 @@ def list_comments(prefix: str, *, is_endmarker: bool) -> List[ProtoComment]:
         )
         nlines = 0
     return result
+# fmt: on
 
 
 def main():

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,13 @@ Changes
 =======
 
 
+2021-XX-XX (0.6.0)
+------------------
+
+- Preserve the whitespace before the hash mark for right hanging comments.
+  (GH#20)
+
+
 2021-01-17 (0.5.2)
 ------------------
 


### PR DESCRIPTION
We're close but not quite there yet!

```
error: cannot format /tmp/bar.py: INTERNAL ERROR: Black produced different code on the second pass of the formatter.  Please report a bug on https://github.com/psf/black/issues.  This diff might be helpful: /var/folders/dg/2gcv7qh1141dfc13k7kbty7w000slb/T/blk_81rqaiyh.log
Oh no! 💥 💔 💥
1 file would fail to reformat.
```

Closes #20