### PR TITLE
Fix --version option handling and add test cases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 doc8
 flake8
 pytest
+pytest-cov
 rstcheck
 sphinx
 tox

--- a/tests/bad_cases/demo.py
+++ b/tests/bad_cases/demo.py
@@ -1,0 +1,64 @@
+# Copied from the Black Playground at https://black.now.sh/ (MIT LICENSE)
+# And reformated with Blue :)
+
+from seven_dwwarfs import Grumpy, Happy, Sleepy, Bashful, Sneezy, Dopey, Doc
+
+x = {"a": 37, "b": 42, "c": 927}
+
+x = 123456789.123456789e123456789
+
+if (
+    very_long_variable_name is not None
+    and very_long_variable_name.field > 0
+    or very_long_variable_name.is_debug
+):
+    z = "hello " + "world"
+else:
+    world = "world"
+    a = "hello {}".format(world)
+    f = rf"hello {world}"
+if this and that:
+    y = "hello " "world"  # Hanging comment
+
+
+class Foo(object):
+    def f(self):
+        return 37 * -2
+
+    def g(self, x, y=42):
+        return y
+
+
+def f(a: List[int]):
+    return 37 - a[42 - u : y ** 3]
+
+
+def very_important_function(
+    template: str,
+    *variables,
+    file: os.PathLike,
+    debug: bool = False,
+):
+    """Applies `variables` to the `template` and writes to `file`."""
+    with open(file, "w") as f:
+        ...
+
+
+# fmt: off
+custom_formatting = [
+    0,  1,  2,
+    3,  4,  5,
+    6,  7,  8,
+]
+# fmt: on
+regular_formatting = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+]

--- a/tests/good_cases/demo.py
+++ b/tests/good_cases/demo.py
@@ -1,0 +1,64 @@
+# Copied from the Black Playground at https://black.now.sh/ (MIT LICENSE)
+# And reformated with Blue :)
+
+from seven_dwwarfs import Grumpy, Happy, Sleepy, Bashful, Sneezy, Dopey, Doc
+
+x = {'a': 37, 'b': 42, 'c': 927}
+
+x = 123456789.123456789e123456789
+
+if (
+    very_long_variable_name is not None
+    and very_long_variable_name.field > 0
+    or very_long_variable_name.is_debug
+):
+    z = 'hello ' + 'world'
+else:
+    world = 'world'
+    a = 'hello {}'.format(world)
+    f = rf'hello {world}'
+if this and that:
+    y = 'hello ' 'world'             # Hanging comment
+
+
+class Foo(object):
+    def f(self):
+        return 37 * -2
+
+    def g(self, x, y=42):
+        return y
+
+
+def f(a: List[int]):
+    return 37 - a[42 - u : y ** 3]
+
+
+def very_important_function(
+    template: str,
+    *variables,
+    file: os.PathLike,
+    debug: bool = False,
+):
+    """Applies `variables` to the `template` and writes to `file`."""
+    with open(file, 'w') as f:
+        ...
+
+
+# fmt: off
+custom_formatting = [
+    0,  1,  2,
+    3,  4,  5,
+    6,  7,  8,
+]
+# fmt: on
+regular_formatting = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+]

--- a/tests/test_blue.py
+++ b/tests/test_blue.py
@@ -1,22 +1,60 @@
 import pathlib
 import subprocess
 
+import black
 import blue
 import pytest
 
 tests_dir = pathlib.Path(__file__).parent.absolute()
 
 
-def test_version():
-    assert blue.__version__
+@pytest.mark.parametrize(
+    'test_dir',
+    [
+        'config_setup',
+        'config_tox',
+        'config_blue',
+        'config_pyproject',
+        'good_cases',
+    ],
+)
+def test_good_dirs(monkeypatch, test_dir):
+    test_dir = tests_dir / test_dir
+    monkeypatch.chdir(test_dir)
+    monkeypatch.setattr('sys.argv', ['blue', '--check', '.'])
+    black.find_project_root.cache_clear()
+    with pytest.raises(SystemExit) as exc_info:
+        blue.main()
+    assert exc_info.value.code == 0
 
 
 @pytest.mark.parametrize(
-    'config_dir',
-    ['config_setup', 'config_tox', 'config_blue', 'config_pyproject'],
+    'test_dir',
+    ['bad_cases'],
 )
-def test_configs(monkeypatch, config_dir):
-    config_dir = tests_dir / config_dir
-    monkeypatch.chdir(config_dir)
-    proc = subprocess.run(f'blue --check .', shell=True)
-    assert proc.returncode == 0
+def test_bad_dirs(monkeypatch, test_dir):
+    test_dir = tests_dir / test_dir
+    monkeypatch.chdir(test_dir)
+    monkeypatch.setattr('sys.argv', ['blue', '--check', '.'])
+    black.find_project_root.cache_clear()
+    with pytest.raises(SystemExit) as exc_info:
+        blue.main()
+    assert exc_info.value.code == 1
+
+
+def test_main(capsys, monkeypatch):
+    monkeypatch.setattr('sys.argv', ['blue', '--version'])
+    with pytest.raises(SystemExit) as exc_info:
+        import blue.__main__
+    assert exc_info.value.code == 0
+
+
+def test_version(capsys, monkeypatch):
+    monkeypatch.setattr('sys.argv', ['blue', '--version'])
+    with pytest.raises(SystemExit) as exc_info:
+        blue.main()
+    assert exc_info.value.code == 0
+    out, err = capsys.readouterr()
+    version = f'blue, version {blue.__version__}, based on black {black.__version__}\n'
+    assert out == version
+    assert err == ''

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,7 @@ deps=
 
 [pytest]
 addopts=
-    --cov-branch
-    --cov-fail-under=87
-    --cov-report=term-missing
-    --cov=blue
+    --cov blue
 testpaths=blue docs tests
 
 [testenv:blue]
@@ -39,6 +36,19 @@ commands=flake8 blue setup.py
 [testenv:rstcheck]
 deps=rstcheck
 commands=rstcheck --report warning README.rst
+
+[coverage:report]
+fail_under=87
+show_missing=true
+
+[coverage:run]
+branch=true
+parallel=true
+omit=
+
+[coverage:paths]
+source=
+    blue
 
 [flake8]
 ignore=

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,17 @@ envlist=bluecheck,doc8,flake8,rstcheck,docs,py36,py37,py38,py39
 skip_missing_interpreters=True
 
 [testenv]
-deps=pytest
 commands=pytest
+deps=
+    pytest
+    pytest-cov
 
 [pytest]
+addopts=
+    --cov-branch
+    --cov-fail-under=87
+    --cov-report=term-missing
+    --cov=blue
 testpaths=blue docs tests
 
 [testenv:blue]


### PR DESCRIPTION
* Previous changes (GH#30) broke --version option handling
* Simplify --version option handling
* Add test case for "good" demo code
* Add test case for "bad" demo code
* Add test case for __main__.py
* Add test case for --version option
* Require coverage at 87%