### PR TITLE
Enable pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: blue
+  name: blue
+  description: "Blue: The gentler Black"
+  entry: bllue
+  language: python
+  language_version: python3
+  minimum_pre_commit_version: 2.9.2
+  require_serial: true
+  types_or: [python, pyi]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: blue
   name: blue
   description: "Blue: The gentler Black"
-  entry: bllue
+  entry: blue
   language: python
   language_version: python3
   minimum_pre_commit_version: 2.9.2


### PR DESCRIPTION
In order for pre-commit hooks to work, a `.pre-commit-hooks.yaml` file must exist in the top level repo.  The pull request adds one that looks very similar to the **black** pre-commit-hooks file.

Resolves Issue Number #50 

FWIW, the `.pre-commit-config.yaml` file that lives in our repo that goes with this file which lives in the blue repo, includes this clause to run blue:
```
- repo: https://github.com/rotten/blue.git
  rev: 0.6.1
  hooks:
  - id: blue
    args:
      - -l120
      - -tpy38
      - --exclude="(app\/node_modules|api\/v0|api\/tests\/v0)"
```
