### PR TITLE
Relax flake8 versions to support flake8 v4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['blue'],
     tests_require=['tox'],
     cmdclass={'test': Tox},
-    install_requires=['black==21.7b0', 'flake8==3.8.4'],
+    install_requires=['black==21.7b0', 'flake8>=3.8.4,<5'],
     project_urls={
         'Documentation': 'https://blue.readthedocs.io/en/latest',
         'Source': 'https://github.com/grantjenks/blue.git',


### PR DESCRIPTION
I recently tried to add blue to a project along with the latest flake8 (4.0.1) but I was suprised to see that it failed to install due to conflict:

```
The conflict is caused by:
    The user requested flake8~=4.0
    blue 0.7.0 depends on flake8==3.8.4

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

Trying to relax the version requested for flake8 so that blue can be installed alongside other tools.