### PR TITLE
Loosen version of Flake8 in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['blue'],
     tests_require=['tox'],
     cmdclass={'test': Tox},
-    install_requires=['black==21.7b0', 'flake8==3.8.4'],
+    install_requires=['black==21.7b0', 'flake8~=3.8'],
     project_urls={
         'Documentation': 'https://blue.readthedocs.io/en/latest',
         'Source': 'https://github.com/grantjenks/blue.git',


### PR DESCRIPTION
We probably don't need to pin to the exact patch version, pinning to the minor version should be enough.