### PR TITLE
Fix the test suite

### DIFF
--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -15,6 +15,14 @@ import sys
 import importlib
 import importlib.machinery
 
+
+if 'black' in sys.modules and sys.modules['black'].__file__.endswith('.so'):
+    raise RuntimeError(
+        'A mypyc-compiled version of black has already been imported. '
+        "This limits blue's ability to monkeypatch black."
+    )
+
+
 class NoMypycBlackFileFinder(importlib.machinery.FileFinder):
     def __init__(self, path: str, *loader_details) -> None:
         super().__init__(path, *loader_details)
@@ -31,16 +39,25 @@ class NoMypycBlackFileFinder(importlib.machinery.FileFinder):
 
     def find_spec(self, fullname, *args, **kw):
         if fullname == 'black' or fullname.startswith('black.'):
-            return super(NoMypycBlackFileFinder, self).find_spec(fullname, *args, **kw)
+            return super(NoMypycBlackFileFinder, self).find_spec(
+                fullname, *args, **kw
+            )
         else:
             return self.original_finder.find_spec(fullname, *args, **kw)
 
     @classmethod
     def path_hook(cls):
         return super(NoMypycBlackFileFinder, cls).path_hook(
-            (importlib.machinery.SourceFileLoader, importlib.machinery.SOURCE_SUFFIXES),
-            (importlib.machinery.SourcelessFileLoader, importlib.machinery.BYTECODE_SUFFIXES),
+            (
+                importlib.machinery.SourceFileLoader,
+                importlib.machinery.SOURCE_SUFFIXES,
+            ),
+            (
+                importlib.machinery.SourcelessFileLoader,
+                importlib.machinery.BYTECODE_SUFFIXES,
+            ),
         )
+
 
 sys.path_hooks.insert(0, NoMypycBlackFileFinder.path_hook())
 sys.path_importer_cache.clear()

--- a/tests/bad_cases/demo.py
+++ b/tests/bad_cases/demo.py
@@ -29,7 +29,7 @@ class Foo(object):
 
 
 def f(a: List[int]):
-    return 37 - a[42 - u : y ** 3]
+    return 37 - a[42 - u : y**3]
 
 
 def very_important_function(

--- a/tests/test_blue.py
+++ b/tests/test_blue.py
@@ -1,9 +1,9 @@
 import asyncio
 import pathlib
-import subprocess
+
+import blue
 
 import black
-import blue
 import pytest
 
 tests_dir = pathlib.Path(__file__).parent.absolute()
@@ -22,7 +22,7 @@ tests_dir = pathlib.Path(__file__).parent.absolute()
 def test_good_dirs(monkeypatch, test_dir):
     test_dir = tests_dir / test_dir
     monkeypatch.chdir(test_dir)
-    monkeypatch.setattr('sys.argv', ['blue', '--check', '.'])
+    monkeypatch.setattr('sys.argv', ['blue', '--check', '--diff', '.'])
     for path in test_dir.rglob('*'):
         path.touch()  # Invalidate file caches in Blue.
     black.find_project_root.cache_clear()
@@ -39,7 +39,7 @@ def test_good_dirs(monkeypatch, test_dir):
 def test_bad_dirs(monkeypatch, test_dir):
     test_dir = tests_dir / test_dir
     monkeypatch.chdir(test_dir)
-    monkeypatch.setattr('sys.argv', ['blue', '--check', '.'])
+    monkeypatch.setattr('sys.argv', ['blue', '--check', '--diff', '.'])
     for path in test_dir.rglob('*'):
         path.touch()  # Invalidate file caches in Blue.
     black.find_project_root.cache_clear()

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ testpaths=blue docs tests
 commands=blue blue docs setup.py tests/test_blue.py
 
 [testenv:bluecheck]
-commands=blue --check blue docs setup.py tests/test_blue.py
+commands=blue --check --diff blue docs setup.py tests/test_blue.py
 
 [testenv:docs]
 allowlist_externals=make
@@ -56,5 +56,6 @@ ignore=
     E124
     E203
     E303
+    E402
     W503
 max-line-length=88


### PR DESCRIPTION
Fixes #72

This is a fun one, involving:
- mypyc
- monkeypatching
- multiprocessing
- import order

You'll notice that almost every subcombination of those four things
is bad.

Monkeypatching mypyc-compiled modules doesn't work.
The import order in test_blue.py meant that while running tests, we
imported black before blue. So it was too late for
NoMypycBlackFileFinder to do its thing.
So that explains failures, but not successes. black uses multiprocessing
internally. In Python 3.8 on macOS, the default start method changed to
spawn from fork. I'm guessing in the child process the code runs in the
order we want and patching works.

I changed bad_cases/demo.py to be correctly black formatted. Might be
useful to have a test that enforces this.