### PR TITLE
Pin flake8 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 doc8
-flake8
+flake8<5.0.0
 pytest
 pytest-cov
 rstcheck

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['blue'],
     tests_require=['tox'],
     cmdclass={'test': Tox},
-    install_requires=['black==22.1.0', 'flake8>=3.8'],
+    install_requires=['black==22.1.0', 'flake8>=3.8,<5.0.0'],
     project_urls={
         'Documentation': 'https://blue.readthedocs.io/en/latest',
         'Source': 'https://github.com/grantjenks/blue.git',


### PR DESCRIPTION
This PR pin the flake8 version to less than `5.0.0` to avoid the error reported at #78.