### PR TITLE
Add classifiers for all tested Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     entry_points={


### PR DESCRIPTION
Some tools or services like https://pyreadiness.org/ use classifiers to check for compatibility with a particular Python version. It would be nice to have this information in `setup.py`.