### PR TITLE
feat: remove flake8 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['blue'],
     tests_require=['tox'],
     cmdclass={'test': Tox},
-    install_requires=['black==22.1.0', 'flake8>=3.8,<5.0.0'],
+    install_requires=['black==22.1.0'],
     project_urls={
         'Documentation': 'https://blue.readthedocs.io/en/latest',
         'Source': 'https://github.com/grantjenks/blue.git',


### PR DESCRIPTION
Fixes: #78 

Blue relies on flake8 to parse config files like 'setup.cfg', 'tox.ini' and '.blue'. This was done using `ConfigParser` and `ConfigFileFinder` classes, but in flake8 v5/6 these classes have been removed.

To fix the problem, all flake8 related code was removed and replace with a new function that parses the config files. This is all done using `ConfigParser` class from [configparser](https://docs.python.org/3.10/library/configparser.html) module. 

The new function is largely inspired by Flake8 own implementation, mainly the `load_config` and `parse_config` functions. 

